### PR TITLE
Add conversational planner and memory support

### DIFF
--- a/dompet_backend/app/api/__init__.py
+++ b/dompet_backend/app/api/__init__.py
@@ -1,0 +1,3 @@
+"""API route modules for the Dompet backend."""
+
+from . import conversation, ingestion, insights  # noqa: F401

--- a/dompet_backend/app/api/conversation.py
+++ b/dompet_backend/app/api/conversation.py
@@ -1,0 +1,40 @@
+"""FastAPI routes for the conversational layer."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ..models.conversation import ConversationMessage, ConversationResponse, MemoryUpdate, UserMemory
+from ..services.conversation import ConversationService, get_memory_store
+from ..services.database import get_session
+
+router = APIRouter()
+
+
+@router.post("/{user_id}/message", response_model=ConversationResponse)
+def converse(
+    user_id: str,
+    payload: ConversationMessage,
+    session=Depends(get_session),
+) -> ConversationResponse:
+    service = ConversationService(session, memory_store=get_memory_store())
+    return service.handle_message(user_id, payload)
+
+
+@router.get("/{user_id}/memory", response_model=UserMemory)
+def read_memory(
+    user_id: str,
+    session=Depends(get_session),  # pragma: no cover - FastAPI dependency injection
+) -> UserMemory:
+    service = ConversationService(session, memory_store=get_memory_store())
+    return service.get_memory(user_id)
+
+
+@router.post("/{user_id}/memory", response_model=UserMemory)
+def update_memory(
+    user_id: str,
+    payload: MemoryUpdate,
+    session=Depends(get_session),  # pragma: no cover - FastAPI dependency injection
+) -> UserMemory:
+    service = ConversationService(session, memory_store=get_memory_store())
+    return service.update_memory(user_id, payload)

--- a/dompet_backend/app/main.py
+++ b/dompet_backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from .api import ingestion, insights
+from .api import conversation, ingestion, insights
 from .core.config import settings
 from .services.database import init_db
 
@@ -18,6 +18,7 @@ def on_startup() -> None:  # pragma: no cover - framework hook
 
 app.include_router(ingestion.router, prefix="/ingestion", tags=["ingestion"])
 app.include_router(insights.router, prefix="/insights", tags=["insights"])
+app.include_router(conversation.router, prefix="/conversation", tags=["conversation"])
 
 
 @app.get("/health", tags=["meta"])

--- a/dompet_backend/app/models/conversation.py
+++ b/dompet_backend/app/models/conversation.py
@@ -1,0 +1,98 @@
+"""Conversation and memory models for the Dompet conversational layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Literal
+
+
+@dataclass
+class FinancialGoal:
+    """Represents a long or short term financial objective."""
+
+    name: str
+    target_amount: float | None = None
+    target_date: date | None = None
+    priority: Literal["low", "medium", "high"] = "medium"
+    notes: str | None = None
+
+
+@dataclass
+class Obligation:
+    """Recurring payment or liability that the user must service."""
+
+    name: str
+    amount: float
+    cadence: Literal["weekly", "monthly", "quarterly", "yearly"] = "monthly"
+    category: str | None = None
+
+
+@dataclass
+class IncomeStream:
+    """Represents a source of income for the household."""
+
+    name: str
+    cadence: Literal["weekly", "biweekly", "monthly", "ad-hoc"] = "monthly"
+    amount: float | None = None
+
+
+@dataclass
+class UserProfile:
+    """Key profile attributes used to personalise recommendations."""
+
+    name: str
+    age: int | None = None
+    household_size: int | None = None
+    location: str | None = None
+    income_streams: list[IncomeStream] = field(default_factory=list)
+    risk_appetite: Literal["conservative", "balanced", "aggressive"] = "balanced"
+
+
+@dataclass
+class ConversationTurn:
+    """Single exchange in the conversation transcript."""
+
+    role: Literal["user", "assistant", "system"]
+    content: str
+    intent: str | None = None
+
+
+@dataclass
+class UserMemory:
+    """Persistent memory bundle for a given user."""
+
+    user_id: str
+    profile: UserProfile | None = None
+    goals: list[FinancialGoal] = field(default_factory=list)
+    obligations: list[Obligation] = field(default_factory=list)
+    conversation_history: list[ConversationTurn] = field(default_factory=list)
+
+
+@dataclass
+class ConversationMessage:
+    """Inbound message from any conversational channel."""
+
+    message: str
+    channel: Literal["chat", "voice", "email"] = "chat"
+    profile: UserProfile | None = None
+    goals: list[FinancialGoal] | None = None
+    obligations: list[Obligation] | None = None
+
+
+@dataclass
+class MemoryUpdate:
+    """Explicit memory update payload via API."""
+
+    profile: UserProfile | None = None
+    goals: list[FinancialGoal] | None = None
+    obligations: list[Obligation] | None = None
+
+
+@dataclass
+class ConversationResponse:
+    """Response returned to the client after the planner executes."""
+
+    message: str
+    actions: list[str]
+    memory: UserMemory

--- a/dompet_backend/app/services/conversation.py
+++ b/dompet_backend/app/services/conversation.py
@@ -1,0 +1,204 @@
+"""Conversation planning and memory services for Dompet."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from threading import Lock
+
+from ..models.conversation import (
+    ConversationMessage,
+    ConversationResponse,
+    ConversationTurn,
+    FinancialGoal,
+    MemoryUpdate,
+    Obligation,
+    UserMemory,
+    UserProfile,
+)
+from .database import InMemorySession
+from .insights import InsightService
+
+
+class ConversationMemoryStore:
+    """Thread-safe in-memory store for conversation memories."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, UserMemory] = {}
+        self._lock = Lock()
+
+    def get_memory(self, user_id: str) -> UserMemory:
+        with self._lock:
+            memory = self._store.get(user_id)
+            if memory is None:
+                memory = UserMemory(user_id=user_id)
+                self._store[user_id] = memory
+            return memory
+
+    def update_memory(
+        self,
+        user_id: str,
+        *,
+        profile: UserProfile | None = None,
+        goals: Iterable[FinancialGoal] | None = None,
+        obligations: Iterable[Obligation] | None = None,
+    ) -> UserMemory:
+        with self._lock:
+            memory = self._store.get(user_id)
+            if memory is None:
+                memory = UserMemory(user_id=user_id)
+            if profile is not None:
+                memory.profile = profile
+            if goals is not None:
+                merged = {goal.name.lower(): goal for goal in memory.goals}
+                for goal in goals:
+                    merged[goal.name.lower()] = goal
+                memory.goals = list(merged.values())
+            if obligations is not None:
+                merged = {obligation.name.lower(): obligation for obligation in memory.obligations}
+                for obligation in obligations:
+                    merged[obligation.name.lower()] = obligation
+                memory.obligations = list(merged.values())
+            self._store[user_id] = memory
+            return memory
+
+    def append_turn(self, user_id: str, turn: ConversationTurn) -> UserMemory:
+        with self._lock:
+            memory = self._store.get(user_id)
+            if memory is None:
+                memory = UserMemory(user_id=user_id)
+            history = list(memory.conversation_history)
+            history.append(turn)
+            memory.conversation_history = history[-20:]
+            self._store[user_id] = memory
+            return memory
+
+
+class ChatPlanner:
+    """Very small rule-based planner with deterministic fallbacks."""
+
+    def plan(self, message: str, memory: UserMemory) -> list[str]:
+        lowered = message.lower()
+        actions: list[str] = []
+
+        if memory.profile is None:
+            actions.append("collect_profile")
+
+        if any(keyword in lowered for keyword in ("cashflow", "summary", "income", "spend", "expense")):
+            if "cashflow_summary" not in actions:
+                actions.append("cashflow_summary")
+
+        if any(keyword in lowered for keyword in ("category", "breakdown", "spending")):
+            actions.append("expense_breakdown")
+
+        if any(keyword in lowered for keyword in ("recommend", "advice", "plan", "goal")):
+            actions.append("recommendations")
+
+        if not actions:
+            actions.append("chit_chat")
+
+        return actions
+
+
+class ConversationService:
+    """Coordinates planning, memory and insights for a conversation."""
+
+    def __init__(
+        self,
+        session: InMemorySession,
+        *,
+        memory_store: ConversationMemoryStore,
+        planner: ChatPlanner | None = None,
+    ) -> None:
+        self.session = session
+        self.memory_store = memory_store
+        self.planner = planner or ChatPlanner()
+        self.insights = InsightService(session)
+
+    def handle_message(self, user_id: str, payload: ConversationMessage) -> ConversationResponse:
+        # Update memory first based on structured payload information.
+        if payload.profile or payload.goals or payload.obligations:
+            memory = self.memory_store.update_memory(
+                user_id,
+                profile=payload.profile,
+                goals=payload.goals,
+                obligations=payload.obligations,
+            )
+        else:
+            memory = self.memory_store.get_memory(user_id)
+
+        actions = self.planner.plan(payload.message, memory)
+        responses: list[str] = []
+
+        self.memory_store.append_turn(
+            user_id,
+            ConversationTurn(role="user", content=payload.message),
+        )
+
+        if "collect_profile" in actions and memory.profile is None:
+            responses.append(
+                "To personalise your financial plan I need some basics like your monthly income, household size, and key goals."
+            )
+
+        if "cashflow_summary" in actions:
+            summary = self.insights.cashflow_summary(user_id)
+            responses.append(
+                "Cashflow summary: income RM{income:.2f}, expenses RM{expense:.2f}, net RM{net:.2f} with a saving rate of {rate:.0%}.".format(
+                    income=summary.total_income,
+                    expense=summary.total_expense,
+                    net=summary.net_cashflow,
+                    rate=summary.saving_rate,
+                )
+            )
+
+        if "expense_breakdown" in actions:
+            breakdown = self.insights.expense_by_category(user_id)
+            if breakdown:
+                categories = ", ".join(f"{name}: RM{amount:.2f}" for name, amount in breakdown.items())
+                responses.append(f"Top spending categories: {categories}.")
+            else:
+                responses.append("I don't have any expense records yet to analyse categories.")
+
+        if "recommendations" in actions:
+            summary = self.insights.cashflow_summary(user_id)
+            recs = self.insights.income_opportunities(summary)
+            if recs:
+                bullet_points = "\n".join(f"- {rec}" for rec in recs)
+                responses.append(f"Here are some tailored next steps:\n{bullet_points}")
+            else:
+                responses.append("You're on track! I'll keep monitoring for new opportunities.")
+
+        if "chit_chat" in actions and not responses:
+            responses.append("I'm here to help with your Malaysian personal finance questions whenever you're ready.")
+
+        assistant_turn = ConversationTurn(
+            role="assistant",
+            content="\n".join(responses) if responses else "Let me know how I can assist with your finances.",
+            intent=";".join(actions),
+        )
+        memory = self.memory_store.append_turn(user_id, assistant_turn)
+
+        return ConversationResponse(
+            message=assistant_turn.content,
+            actions=actions,
+            memory=memory,
+        )
+
+    def update_memory(self, user_id: str, payload: MemoryUpdate) -> UserMemory:
+        return self.memory_store.update_memory(
+            user_id,
+            profile=payload.profile,
+            goals=payload.goals,
+            obligations=payload.obligations,
+        )
+
+    def get_memory(self, user_id: str) -> UserMemory:
+        return self.memory_store.get_memory(user_id)
+
+
+_MEMORY_STORE = ConversationMemoryStore()
+
+
+def get_memory_store() -> ConversationMemoryStore:
+    """Return the singleton in-memory memory store."""
+
+    return _MEMORY_STORE

--- a/dompet_backend/tests/test_conversation.py
+++ b/dompet_backend/tests/test_conversation.py
@@ -1,0 +1,87 @@
+from datetime import date
+
+from dompet_backend.app.models.conversation import ConversationMessage, FinancialGoal, UserProfile
+from dompet_backend.app.models.transaction import TransactionIn
+from dompet_backend.app.services.conversation import ConversationMemoryStore, ConversationService
+from dompet_backend.app.services.database import get_session, init_db
+from dompet_backend.app.services.ingestion import StatementIngestionService
+
+
+def setup_module() -> None:  # pragma: no cover - setup
+    init_db()
+
+
+def test_conversation_requests_profile_when_missing() -> None:
+    session_gen = get_session()
+    session = next(session_gen)
+    memory_store = ConversationMemoryStore()
+    service = ConversationService(session, memory_store=memory_store)
+
+    response = service.handle_message("user-1", ConversationMessage(message="Hello"))
+
+    assert "collect_profile" in response.actions
+    assert "need some basics" in response.message.lower()
+
+    try:
+        next(session_gen)
+    except StopIteration:
+        pass
+
+
+def test_conversation_generates_summary_and_recommendations() -> None:
+    init_db()
+    session_gen = get_session()
+    session = next(session_gen)
+
+    ingestion_service = StatementIngestionService(session)
+    ingestion_service.ingest_transactions(
+        [
+            TransactionIn(
+                user_id="user-42",
+                posted_date=date(2024, 1, 1),
+                description="Salary",
+                amount=5000.0,
+                category="income",
+            ),
+            TransactionIn(
+                user_id="user-42",
+                posted_date=date(2024, 1, 5),
+                description="Rent",
+                amount=-1500.0,
+                category="housing",
+            ),
+            TransactionIn(
+                user_id="user-42",
+                posted_date=date(2024, 1, 10),
+                description="Groceries",
+                amount=-600.0,
+                category="food",
+            ),
+        ]
+    )
+
+    memory_store = ConversationMemoryStore()
+    service = ConversationService(session, memory_store=memory_store)
+
+    response = service.handle_message(
+        "user-42",
+        ConversationMessage(
+            message="Can you give me a cashflow summary and recommendations?",
+            profile=UserProfile(name="Aisha", age=32, household_size=3),
+            goals=[FinancialGoal(name="Emergency fund", target_amount=12000.0)],
+        ),
+    )
+
+    assert "cashflow_summary" in response.actions
+    assert "recommendations" in response.actions
+    assert "cashflow summary" in response.message.lower()
+    assert "tailored" in response.message.lower()
+    assert response.memory.profile is not None
+    assert response.memory.profile.name == "Aisha"
+    assert len(response.memory.goals) == 1
+    assert response.memory.conversation_history[-1].role == "assistant"
+
+    try:
+        next(session_gen)
+    except StopIteration:
+        pass


### PR DESCRIPTION
## Summary
- add conversational memory models and rule-based planner service for the chat layer
- expose conversation and memory management endpoints and wire them into the FastAPI app
- cover the new planner behaviour with conversation-focused tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4c8d0e73883209c3a7aa5db71d67f